### PR TITLE
Adding the mask_for method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -64,6 +64,10 @@ It works like this:
   >> u.roles_mask
   => 3
 
+  # see the role mask for a certain role(s)
+  >> User.mask_for :admin, :author
+  => 5
+
 Once you have included RoleModel, your model is perfectly fit to be used
 together with a role-based authorization solution, such as
 http://github.com/ryanb/cancan or

--- a/lib/role_model/class_methods.rb
+++ b/lib/role_model/class_methods.rb
@@ -28,5 +28,9 @@ module RoleModel
     def roles(*roles)
       self.valid_roles = Array[*roles].flatten.map { |r| r.to_sym }
     end
+
+    def mask_for(*roles)
+      (Array[*roles].flatten.map { |r| r.to_sym } & valid_roles).map { |r| 2**valid_roles.index(r) }.inject { |sum, bitvalue| sum + bitvalue } || 0
+    end
   end
 end

--- a/spec/role_model_spec.rb
+++ b/spec/role_model_spec.rb
@@ -359,4 +359,45 @@ describe RoleModel do
     end
   end
 
+  describe ".mask_for" do
+    subject { model_class.new }
+
+    before(:each) do
+      model_class.instance_eval do
+        attr_accessor :roles_mask
+        attr_accessor :custom_roles_mask
+        include RoleModel
+        roles :foo, :bar, :third
+      end
+    end
+
+    context "passing" do
+      it "should return the role mask of a role" do
+        subject.class.mask_for(:foo).should == 1
+        subject.class.mask_for(:bar).should == 2
+        subject.class.mask_for(:third).should == 4
+      end
+
+      it "should return the role mask of an array of roles" do
+        subject.class.mask_for(:foo, :bar).should == 3
+        subject.class.mask_for(:foo, :third).should == 5
+        subject.class.mask_for(:foo, :bar, :third).should == 7
+      end
+
+      it "should return the role mask of a string array of roles" do
+        subject.class.mask_for("foo").should == 1
+        subject.class.mask_for("foo", "bar").should == 3
+        subject.class.mask_for("foo", "third").should == 5
+      end
+
+      it "should return the role mask of the existing roles" do
+        subject.class.mask_for(:foo, :quux).should == 1
+      end
+
+      it "should return 0 when a role that does not exist is passed" do
+        subject.class.mask_for(:quux).should == 0
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
I created the mask_for method as a useful way to search the users which match with a single role mask. For example, I could use it for getting this kind of searchs:

User.where(:role_mask => User.mask_for(:admin))

I think it would be useful for a later version of the gem when the user could search like this:

User.where(:role => :admin)
