### PR TITLE
Add `class.mask_values_for` function

### DIFF
--- a/lib/role_model/class_methods.rb
+++ b/lib/role_model/class_methods.rb
@@ -23,7 +23,19 @@ module RoleModel
 
       (valid_roles & sanitized_roles).inject(0) { |sum, role| sum + 2**valid_roles.index(role) }
     end
-    
+
+    def mask_values_for(*roles)
+      indexes = (roles.map(&:to_sym) & valid_roles).map { |role| valid_roles.index(role) }
+      if indexes.length > 0
+        indexes.map do |index|
+          sig_bit = 2**index
+          (0..2**valid_roles.length).map do |i|
+            (i & sig_bit).zero? ? nil : i
+          end.compact
+        end.reduce(:&)
+      end
+    end
+
     protected
 
     # :call-seq:
@@ -40,7 +52,7 @@ module RoleModel
         self.define_dynamic_queries(self.valid_roles)
       end
     end
-    
+
     # Defines dynamic queries for :role
     #   #is_<:role>?
     #   #<:role>?

--- a/spec/role_model_spec.rb
+++ b/spec/role_model_spec.rb
@@ -594,4 +594,34 @@ describe RoleModel do
     end
   end
 
+  describe ".mask_values_for" do
+    subject { model_class.new }
+
+    it "should return an array of valid role_mask values for the given role" do
+      subject.class.mask_values_for(:foo).should == [1, 3, 5, 7]
+      subject.class.mask_values_for(:bar).should == [2, 3, 6, 7]
+      subject.class.mask_values_for(:third).should == [4, 5, 6, 7]
+    end
+
+    it "should return the role mask of an array of roles" do
+      subject.class.mask_values_for(:foo, :bar).should == [3, 7]
+      subject.class.mask_values_for(:foo, :third).should == [5, 7]
+      subject.class.mask_values_for(:foo, :bar, :third).should == [7]
+    end
+
+    it "should work with strings" do
+      subject.class.mask_values_for("foo").should == [1, 3, 5, 7]
+      subject.class.mask_values_for("foo", "bar").should == [3, 7]
+      subject.class.mask_values_for("foo", "third").should == [5, 7]
+    end
+
+    it "should return the role mask of the existing roles" do
+      subject.class.mask_values_for(:foo, :quux).should == [1, 3, 5, 7]
+    end
+
+    it "should return nil when the passed in role is invalid" do
+      subject.class.mask_values_for(:quux).should == nil
+    end
+  end
+
 end


### PR DESCRIPTION
Added a function that will return the valid values of `role_mask` for the given roles.

This function is very useful for making `SQL` queries based on role. For example, in your Rails model you may want to define a scope like so:

``` ruby
class User < ActiveRecord::Base
  roles :admin
  scope :admin, where(roles_mask: self.mask_values_for(:admin))
end
```

or

``` ruby
class RestaurantStaff < ActiveRecord::Base
  roles :chef, :sous_chef, :bartender, :waiter
  scope :chefs, where(roles_mask: self.mask_values_for(:chef, :sous_chef))
end
```

The primary down side to this function is that the return value will start to get unwieldy when you have > 10 roles. I expect this is uncommon for most uses though.
